### PR TITLE
Minor software updates

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   run-linters:

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ setup(
     license="BSD 3-Clause",
     packages=["ponyo"],
     zip_safe=False,
+    python_requires="=3.5, <3.8",
     install_requires=[
-        "python>=3.5, <3.8",
         "pandas",
         "numpy",
         "keras==2.3.1",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras = {
 
 setup(
     name="ponyo",
-    version="0.3",
+    version="0.4",
     description="Install functions to simulate gene expression compendia",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -34,6 +34,7 @@ setup(
     packages=["ponyo"],
     zip_safe=False,
     install_requires=[
+        "python>=3.5, <3.8"
         "pandas",
         "numpy",
         "keras==2.3.1",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     packages=["ponyo"],
     zip_safe=False,
     install_requires=[
-        "python>=3.5, <3.8"
+        "python>=3.5, <3.8",
         "pandas",
         "numpy",
         "keras==2.3.1",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pandas",
         "numpy",
         "keras==2.3.1",
-        "tensorflow==1.15.4",
+        "tensorflow==2.0.0",
         "scikit-learn",
         "h5py<3",
     ],

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     license="BSD 3-Clause",
     packages=["ponyo"],
     zip_safe=False,
-    python_requires="=3.5, <3.8",
+    python_requires=">=3.5, <3.8",
     install_requires=[
         "pandas",
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pandas",
         "numpy",
         "keras==2.3.1",
-        "tensorflow==2.0.0",
+        "tensorflow==1.15.4",
         "scikit-learn",
         "h5py<3",
     ],


### PR DESCRIPTION
This PR is addressing a couple of software updates that will be included in ponyo version 0.4, which will also include functional changes from https://github.com/greenelab/ponyo/pull/29

Changes include:
* Setting version of coveralls to fix error: https://github.com/greenelab/ponyo/issues/30
* Add python version restriction which will help to stabilize version of TF used: https://github.com/greenelab/ponyo/issues/28. Looks like upgrading to TF 2.0 breaks some dependencies https://github.com/tensorflow/tensorflow/issues/33504 so I will leave the current version of TF as is