### PR TITLE
Split reconstruction and KL loss, and log them as metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras = {
 
 setup(
     name="ponyo",
-    version="0.6",
+    version="0.6.1",
     description="Install functions to simulate gene expression compendia",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This PR splits the vae loss into its two separate components, reconstruction and kl loss, so that they are both displayed during training. This also allows you to access them individually through the history variable.

No rush on reviewing this PR, I just posted the code here so I didn't forget I had it.